### PR TITLE
Update to upload-pages-artifact@v3

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -42,7 +42,7 @@ jobs:
           outputFile: ./_site/whipp-CV.pdf
           pdfOptions: '{"format": "A4", "margin": {"top": "10mm", "left": "10mm", "right": "10mm", "bottom": "10mm"}}'
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
 
   # Deployment job
   deploy:


### PR DESCRIPTION
It appears that upload-pages-artifact@v2 uses upload-artifact@v3, which has been deprecated.